### PR TITLE
Delete alias from stg_sales_database__order_item

### DIFF
--- a/models/staging/sales_database/stg_sales_database__order_item.sql
+++ b/models/staging/sales_database/stg_sales_database__order_item.sql
@@ -5,6 +5,6 @@ select CONCAT(order_id, '_', product_id) AS order_item_id,
  DATETIME(pickup_limit_date, "Europe/Paris") AS picked_up_limited_at,
  price as unit_price,
  shipping_cost,
- quantity as item_quantity,
+ quantity,
  (price * quantity) + shipping_cost as total_order_item_amount
 from {{ source('sales_database', 'order_item') }}


### PR DESCRIPTION
In this Pull request, the alias '`item_quantity`' has been deleted from the columns quantity of the `stg_sales_database__order_item` model